### PR TITLE
fix(ci): reliable release trigger + accurate README asset names

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -2,7 +2,7 @@ name: Build Release Binaries
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This creates `tv-media-conv.exe` which includes the entire Bun runtime. The exec
 
 ### CI/CD Builds
 
-GitHub Actions automatically builds binaries for all platforms when a release is created:
+GitHub Actions automatically builds binaries for all platforms when a release is published:
 
 - **Windows**: `tv-media-conv-windows-x64.exe` (x64)
 - **macOS**: `tv-media-conv-darwin-x64` (Intel), `tv-media-conv-darwin-arm64` (Apple Silicon)

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ This creates `tv-media-conv.exe` which includes the entire Bun runtime. The exec
 
 GitHub Actions automatically builds binaries for all platforms when a release is created:
 
-- **Windows**: `tv-media-conv.exe` (x64)
-- **macOS**: `tv-media-conv` (Intel), `tv-media-conv-arm64` (Apple Silicon)
-- **Linux**: `tv-media-conv` (x64), `tv-media-conv-arm64` (ARM64)
+- **Windows**: `tv-media-conv-windows-x64.exe` (x64)
+- **macOS**: `tv-media-conv-darwin-x64` (Intel), `tv-media-conv-darwin-arm64` (Apple Silicon)
+- **Linux**: `tv-media-conv-linux-x64` (x64), `tv-media-conv-linux-arm64` (ARM64)
 
 To trigger a build with all binaries, create a GitHub release. The binaries are automatically attached to the release as downloadable assets.


### PR DESCRIPTION
Two small correctness fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release asset filenames in documentation to reflect platform-specific naming: Windows (`tv-media-conv-windows-x64.exe`), macOS (`tv-media-conv-darwin-x64`, `darwin-arm64`), and Linux (`tv-media-conv-linux-x64`, `linux-arm64`).

* **Chores**
  * Updated release workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->